### PR TITLE
remove setuptools from runtime dependencies, it's only a build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
   'Topic :: Text Processing :: Fonts',
 ]
 dependencies = [
-  'setuptools',
   'fontTools',
   'ufoLib2',
 ]


### PR DESCRIPTION
setuptools is already listed in `[build-system] requires` key, there is no need to add it as a run-time dependency, it does not seem like the ufomerge library imports setuptools (grep setuptools finds nothing inside Lib/).