### PR TITLE
Drop SinglePosStatement if prefix or suffix is empty

### DIFF
--- a/Lib/ufomerge/__init__.py
+++ b/Lib/ufomerge/__init__.py
@@ -415,7 +415,11 @@ class UFOMerger:
                 st.suffix = self.filter_sequence(st.suffix)
                 container, vr = st.pos[0]
                 st.pos = [(self.filter_glyph_container(container), vr)]
-                if not st.pos[0][0].glyphSet():
+                if (
+                    any(not sequence.glyphSet() for sequence in st.prefix)
+                    or any(not sequence.glyphSet() for sequence in st.suffix)
+                    or not st.pos[0][0].glyphSet()
+                ):
                     continue
 
             newstatements.append(st)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -123,3 +123,38 @@ def test_languagesystems(helpers):
       } ccmp;
     """,
     )
+
+
+def test_drop_contextual_empty_class(helpers):
+    ufo2 = helpers.create_ufo_from_features(
+        """
+        @DAGESH = [dagesh-hb];
+        @OFFENDING_PUNCTUATION = [period];
+
+        lookup hebrew_mark_resolve_clashing_punctuation {
+            lookupflag RightToLeft;
+            pos [vav-hb zayin-hb] @DAGESH @OFFENDING_PUNCTUATION' 60;
+        } hebrew_mark_resolve_clashing_punctuation;
+
+        feature kern {
+            lookup hebrew_mark_resolve_clashing_punctuation;
+        } kern;
+        """
+    )
+    ufo1 = subset_ufo(ufo2, glyphs=["period"])
+
+    helpers.assert_features_similar(
+        ufo1,
+        """
+        @DAGESH = [];
+        @OFFENDING_PUNCTUATION = [period];
+
+        lookup hebrew_mark_resolve_clashing_punctuation {
+            lookupflag RightToLeft;
+        } hebrew_mark_resolve_clashing_punctuation;
+
+        feature kern {
+            lookup hebrew_mark_resolve_clashing_punctuation;
+        } kern;
+        """,
+    )


### PR DESCRIPTION
This drops SinglePos contextual statements with empty prefix or suffix.

Closes https://github.com/googlefonts/ufomerge/issues/3.