### PR TITLE
Drop redundant blocks and ghosts

### DIFF
--- a/Lib/ufomerge/__init__.py
+++ b/Lib/ufomerge/__init__.py
@@ -664,6 +664,9 @@ class UFOMerger:
             return container
         if isinstance(container, ast.GlyphClass):
             container.glyphs = self.filter_glyphs(container.glyphs)
+            # I don't know what `original` is for, but it can undo subsetting
+            # when calling asFea():
+            container.original = []
             return container
         if isinstance(container, ast.GlyphClassName):
             # Filter the class, see if there's anything left

--- a/Lib/ufomerge/__init__.py
+++ b/Lib/ufomerge/__init__.py
@@ -332,6 +332,10 @@ class UFOMerger:
                 substantive_statements = [
                     x for x in st.statements if not isinstance(x, ast.Comment)
                 ]
+                if len(substantive_statements) == 1 and isinstance(
+                    substantive_statements[0], ast.LookupFlagStatement
+                ):
+                    substantive_statements.clear()
                 if not substantive_statements:
                     if isinstance(st, ast.FeatureBlock):
                         continue

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -150,7 +150,6 @@ def test_drop_contextual_empty_class(helpers):
         @OFFENDING_PUNCTUATION = [period];
 
         lookup hebrew_mark_resolve_clashing_punctuation {
-            lookupflag RightToLeft;
         } hebrew_mark_resolve_clashing_punctuation;
 
         feature kern {

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -157,3 +157,32 @@ def test_drop_contextual_empty_class(helpers):
         } kern;
         """,
     )
+
+def test_drop_mark_class(helpers):
+    ufo2 = helpers.create_ufo_from_features(
+        """
+        @something = [ a c ];
+
+        markClass @something <anchor 100 200> @MC_above;
+
+        feature mark {
+            lookup MARK_BASE_above {
+                @bGC_A_above = [A];
+                pos base @bGC_A_above <anchor 150 200> mark @MC_above;
+            } MARK_BASE_above;
+        } mark;
+        """
+    )
+    ufo1 = subset_ufo(ufo2, glyphs=["A"])
+
+    helpers.assert_features_similar(
+        ufo1,
+        """
+        @something = [];
+        feature mark {
+            lookup MARK_BASE_above {
+                @bGC_A_above = [A];
+            } MARK_BASE_above;
+        } mark;
+        """,
+    )


### PR DESCRIPTION
* Drop a block when it is only a lookup flag
* Drop GlyphClass.original because it interferes with subsetting
* Drop post statements in lookups that reference dropped mark classes (closes #10)