### PR TITLE
Cull unwanted named features

### DIFF
--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -231,3 +231,20 @@ def test_deduplicate_classes(helpers):
         } rlig;
         """,
     )
+
+
+def test_cull_unwanted_named_features(helpers) -> None:
+    ufo1 = helpers.create_ufo([])
+    ufo2 = helpers.create_ufo(["a", "a.alt", "b"])
+    ufo2.features.text = """
+        feature ss01 {
+            featureNames {
+                name "Single story a";
+            };
+            sub a by a.alt;
+        } ss01;
+    """
+
+    merge_ufos(ufo1, ufo2, ["b"])
+
+    assert "ss01" not in ufo1.features.text


### PR DESCRIPTION
Currently, if a feature in `ufo2` has a name, it'll be included in `ufo1` regardless as to whether or not it's relevant

Further context [here](https://chat.google.com/room/AAAAmakukgk/260pbEBx-c8/fAZuhJEZqpw?cls=10)

@simoncozens hope this helps!