### PR TITLE
Prune consecutive subtables

### DIFF
--- a/Lib/ufomerge/layout.py
+++ b/Lib/ufomerge/layout.py
@@ -355,6 +355,8 @@ def visit(visitor, block, *args, **kwargs):
     block.statements = [
         statement for statement in block.statements if getattr(statement, "_keep", True)
     ]
+    # Having multiple consecutive subtable statements breaks compilation
+    block.statements = prune_consecutive_subtables(block.statements)
     setattr(
         block,
         "_keep",
@@ -441,6 +443,24 @@ def visit(_visitor, st, *args, **kwargs):
 def visit(_visitor, st, *args, **kwargs):
     st._keep = "maybe"
     return False
+
+
+def prune_consecutive_subtables(statements: list[ast.Statement]) -> list[ast.Statement]:
+    if not statements:
+        return statements
+
+    pruned = []
+    for statement in statements:
+        if isinstance(statement, ast.SubtableStatement) and (
+            not pruned or isinstance(pruned[-1], ast.SubtableStatement)
+        ):
+            continue
+        pruned.append(statement)
+
+    if isinstance(pruned[-1], ast.SubtableStatement):
+        del pruned[-1]
+
+    return pruned
 
 
 class LayoutClosureVisitor(Visitor):


### PR DESCRIPTION
Having a fea block like this after subsetting/merging:

```fea
lookup my_fave_lookup {
  lookupflag IgnoreMarks;
  subtable;
  subtable;
} my_fave_lookup;
```

breaks compilation. We added a workaround that will prune _some_ instances of redundant `subtable` statements (but will probably still produce fea code that can't compile in more nuanced circumstances). However, this unblocks our use case.