### PR TITLE
Use incoming glyphset to subset features of ufo2 when using subset layout handling

### DIFF
--- a/Lib/ufomerge/__init__.py
+++ b/Lib/ufomerge/__init__.py
@@ -192,7 +192,7 @@ class UFOMerger:
                 count = len(self.final_glyphset)
 
         if self.layout_handling != "ignore":
-            subsetter = LayoutSubsetter(glyphset=self.final_glyphset)
+            subsetter = LayoutSubsetter(glyphset=self.incoming_glyphset.keys())
             if self.duplicate_lookup_handling == "first":
                 ufo1path = getattr(self.ufo1, "_path", None)
                 includeDir = (

--- a/Lib/ufomerge/__init__.py
+++ b/Lib/ufomerge/__init__.py
@@ -4,9 +4,10 @@ import copy
 from io import StringIO
 import logging
 from collections import defaultdict
+from collections.abc import Set
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping, OrderedDict, Set, Tuple, Optional, Union
+from typing import Iterable, Tuple, Optional, Union
 import re
 
 from fontTools.feaLib.parser import Parser

--- a/Lib/ufomerge/layout.py
+++ b/Lib/ufomerge/layout.py
@@ -1,7 +1,8 @@
 import logging
 from collections import defaultdict
+from collections.abc import Set
 from dataclasses import dataclass, field
-from typing import Dict, OrderedDict, Set
+from typing import Dict, OrderedDict
 
 from fontTools.feaLib import ast
 from fontTools.misc.visitor import Visitor

--- a/Lib/ufomerge/utils.py
+++ b/Lib/ufomerge/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, Mapping, Optional, List, Dict, Set
+from typing import Any, Iterable, Mapping, Optional, List, Dict
+from collections.abc import Set
 from fontTools.feaLib import ast
 import copy
 


### PR DESCRIPTION
Previously, this used the final glyph set, meaning that if we had /a in ufo1 and a feature in ufo2 referencing /a, that feature would be preserved, even if /a was not on the list of glyphs being merged.

This wasn't desirable in our use case - hence the PR - but maybe it would be for others? This could potentially spin out into another `layout_handling` option if you think this change will break some use cases.

Also updated the type hint import to be able to use `.keys()` as a set without red squiggles everywhere.